### PR TITLE
Added optimistic mode to templated numbers

### DIFF
--- a/console-fan.yaml
+++ b/console-fan.yaml
@@ -55,6 +55,7 @@ number:
     min_value: 0
     max_value: 50
     step: 0.001
+    optimistic: true
     set_action: 
       lambda: |- 
         id(console_thermostat).set_kp( x );
@@ -68,6 +69,7 @@ number:
     min_value: 0
     max_value: 50
     step: 0.0001
+    optimistic: true
     set_action: 
       lambda: id(console_thermostat).set_ki( x );
 
@@ -80,6 +82,7 @@ number:
     min_value: -50
     max_value: 50
     step: 0.001
+    optimistic: true
     set_action: 
       lambda: id(console_thermostat).set_kd( x );
 
@@ -92,6 +95,7 @@ number:
     min_value: -20
     max_value: 0
     step: 0.1
+    optimistic: true
     set_action: 
       lambda: id(console_thermostat).set_threshold_low( x );
 
@@ -104,6 +108,7 @@ number:
     min_value: 0
     max_value: 20
     step: 0.1
+    optimistic: true
     set_action: 
       lambda: id(console_thermostat).set_threshold_high( x );
 
@@ -116,6 +121,7 @@ number:
     min_value: 0
     max_value: .2
     step: 0.01
+    optimistic: true
     set_action: 
       lambda: id(console_thermostat).set_ki_multiplier( x );
 


### PR DESCRIPTION
Documentation https://esphome.io/components/number/template.html#configuration-variables

If not enabled, the UI values will be forgotten on page reload. I'm using HA 2024.10.3 & ESPHome 2024.10.0.